### PR TITLE
Simplify running the checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v1.3.0 (2020-09-10)
+
+#### :rocket: New Feature
+
+* Simplify running the checker:
+  ```
+  npx @v4fire/typescript-check
+  ```
+  instead of
+  ```
+  node ./node_modules/@v4fire/typescript-check/index.js
+  ```
+
 ## v1.2.0 (2020-08-28)
 
 #### :rocket: New Feature

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 npm install @v4fire/typescript-check
-node ./node_modules/@v4fire/typescript-check/index.js
+npx @v4fire/typescript-check
 ```
 
 Usage with github actions:
@@ -42,17 +42,17 @@ jobs:
         run: npx gulp build:tsconfig
 
       - name: Typecheck
-        run: node node_modules/@v4fire/typescript-check/index.js
+        run: npx @v4fire/typescript-check
 ```
 
 ### Setting up a CLI logger
 
 ```
-node ./node_modules/@v4fire/typescript-check/index.js --logger cli
+npx @v4fire/typescript-check --logger cli
 ```
 
 ### Setting up errors threshold
 
 ```
-node ./node_modules/@v4fire/typescript-check/index.js --max-errors 70
+npx @v4fire/typescript-check --max-errors 70
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const
 	ts = require("typescript"),
 	fs = require("fs"),

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Tool to check typescript errors",
   "homepage": "https://github.com/v4fire/typescriptCheck#readme",
   "main": "index.js",
+  "bin": "index.js",
   "license": "MIT",
   "author": "bonkalol@list.ru",
   "scripts": {


### PR DESCRIPTION
The PR allows running the checker in more handy way:

```
npx @v4fire/typescript-check
```
instead of
```
node ./node_modules/@v4fire/typescript-check/index.js
```